### PR TITLE
OCA chat completions and responses bug fix

### DIFF
--- a/src/core/api/transform/openai-response-format.ts
+++ b/src/core/api/transform/openai-response-format.ts
@@ -162,15 +162,23 @@ export function convertToOpenAIResponsesInput(messages: ClineStorageMessage[]): 
 						assistantItems.push(imageItem)
 						break
 					case "tool_use": {
-						// Function calls use call_id, not related to reasoning item ID
-						const call_id = part.call_id || part.id
-						if (part.call_id) {
-							toolUseIdToCallId.set(part.id, part.call_id)
+						// Function calls use call_id; normalize IDs so Responses API-compatible ("fc_...")
+						const normalizeFcId = (v?: string) => {
+							if (!v) return undefined
+							if (v.startsWith("fc_")) return v
+							if (v.startsWith("call_")) return v.replace(/^call_/, "fc_")
+							return v
+						}
+						const normalizedId = normalizeFcId(part.id) || `fc_${Date.now()}`
+						const call_id = normalizeFcId(part.call_id) || normalizedId
+						// Remember mapping from original tool_use id to the normalized call_id so tool_result can pair
+						if (part.id) {
+							toolUseIdToCallId.set(part.id, call_id)
 						}
 						assistantItems.push({
 							type: "function_call",
 							call_id,
-							id: part.id,
+							id: normalizedId,
 							name: part.name,
 							arguments: JSON.stringify(part.input ?? {}),
 						})


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

Sometimes chat completions with GPT 5 model family can return tool calls with the id starting with "call_" when Responses API expects "fc_". This PR fixes this by just checking if the tool call has an id of "call_" and changing it to "fc_" before sending the input to our Responses API endpoint.

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
