### PR TITLE
Fixing tool call issues that arise from switching between Responses API and Chat Completions API

### DIFF
--- a/src/core/api/providers/oca.ts
+++ b/src/core/api/providers/oca.ts
@@ -332,15 +332,19 @@ export class OcaHandler implements ApiHandler {
 	}
 
 	convertIdToResponseFormat(input: OpenAI.Responses.ResponseInputItem[]): OpenAI.Responses.ResponseInputItem[] {
+		const updateToolCallId = (toolCallId: string) => {
+			return toolCallId.replace("call", "fc")
+		}
+
 		return input.map((message) => {
 			if (message.type == "function_call" || message.type == "function_call_output") {
 				const id = message.id
 				const callId = message.call_id
 				if (id && id.startsWith("call")) {
-					message.id = id.replace("call", "fc")
+					message.id = updateToolCallId(id)
 				}
 				if (callId && callId.startsWith("call")) {
-					message.call_id = callId.replace("call", "fc")
+					message.call_id = updateToolCallId(callId)
 				}
 			}
 			return message

--- a/src/core/api/providers/oca.ts
+++ b/src/core/api/providers/oca.ts
@@ -165,9 +165,38 @@ export class OcaHandler implements ApiHandler {
 		}
 	}
 
+	convertToolsToChatFormat(
+		messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[],
+	): OpenAI.Chat.Completions.ChatCompletionMessageParam[] {
+		const updateToolCallId = (toolCallId: string) => {
+			return toolCallId.replace("fc", "call").substring(0, 29)
+		}
+
+		return messages.map((message) => {
+			if (message.role == "tool") {
+				const tool_call_id = message.tool_call_id
+				if (tool_call_id.startsWith("fc")) {
+					message.tool_call_id = updateToolCallId(tool_call_id)
+				}
+			} else if (message.role == "assistant" && message.tool_calls) {
+				const new_tool_calls = message.tool_calls.map((toolCall) => {
+					if (toolCall.id.startsWith("fc")) {
+						toolCall.id = updateToolCallId(toolCall.id)
+					}
+					return toolCall
+				})
+				message.tool_calls = new_tool_calls
+			}
+			return message
+		})
+	}
+
 	async *createMessageChatApi(systemPrompt: string, messages: ClineStorageMessage[], tools?: OpenAITool[]): ApiStream {
 		const client = this.ensureClient()
-		const formattedMessages = convertToOpenAiMessages(messages)
+
+		let formattedMessages = convertToOpenAiMessages(messages)
+		formattedMessages = this.convertToolsToChatFormat(formattedMessages)
+
 		const systemMessage: OpenAI.Chat.ChatCompletionSystemMessageParam = {
 			role: "system",
 			content: systemPrompt,
@@ -302,14 +331,31 @@ export class OcaHandler implements ApiHandler {
 		}
 	}
 
+	convertIdToResponseFormat(input: OpenAI.Responses.ResponseInputItem[]): OpenAI.Responses.ResponseInputItem[] {
+		return input.map((message) => {
+			if (message.type == "function_call" || message.type == "function_call_output") {
+				const id = message.id
+				const callId = message.call_id
+				if (id && id.startsWith("call")) {
+					message.id = id.replace("call", "fc")
+				}
+				if (callId && callId.startsWith("call")) {
+					message.call_id = callId.replace("call", "fc")
+				}
+			}
+			return message
+		})
+	}
+
 	async *createMessageResponsesApi(systemPrompt: string, messages: ClineStorageMessage[], tools?: OpenAITool[]): ApiStream {
 		const client = this.ensureClient()
 
 		// Convert messages to Responses API input format
-		const input: OpenAI.Responses.ResponseInputItem[] = [
+		let input: OpenAI.Responses.ResponseInputItem[] = [
 			{ role: "system", content: systemPrompt },
 			...convertToOpenAIResponsesInput(messages),
 		]
+		input = this.convertIdToResponseFormat(input)
 
 		// Convert ChatCompletion tools to Responses API format if provided
 		const responseTools = tools


### PR DESCRIPTION
### Related Issue

### Description

Added an extra sweep through the input in both Responses API and Chat Completions API that changes the IDs to match what is required for each

### Test Procedure



### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

### Additional Notes